### PR TITLE
Issue #41: Include Pantheon dev/test/live URLs in trusted host patterns.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -119,6 +119,13 @@ $settings['hash_salt'] = '';
  */
 // $settings['trusted_host_patterns'] = array('^www\.example\.com$');
 
+if (defined('PANTHEON_ENVIRONMENT')) {
+  if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array('dev', 'test', 'live'))) {
+    $settings['trusted_host_patterns'][] = "{$_ENV['PANTHEON_ENVIRONMENT']}-{$_ENV['PANTHEON_SITE_NAME']}.pantheon.io";
+    $settings['trusted_host_patterns'][] = "{$_ENV['PANTHEON_ENVIRONMENT']}-{$_ENV['PANTHEON_SITE_NAME']}.pantheonsite.io";
+  }
+}
+
 /**
  * Base URL (optional).
  *


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdrop-pantheon/issues/41