### PR TITLE
Issue #68: Bump MariaDB version to 10.4

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,6 +4,8 @@
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
 php_version: 7.4
+database:
+  version: 10.4
 drush_version: 8
 filemount: /files
 protected_web_paths:


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdrop-pantheon/issues/68

The official Drupal upstream is using 10.4, so that's available: https://github.com/pantheon-systems/drupal-composer-managed/blob/default/pantheon.upstream.yml